### PR TITLE
Improve mobile guide carousel, left-edge sidebar toggle, and mobile scroll markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,7 +667,29 @@
             }
 
             .guide-row {
+                flex-direction: row;
+                overflow-x: auto;
+                scroll-snap-type: x mandatory;
+                -webkit-overflow-scrolling: touch;
+                padding-bottom: 8px;
+                gap: 16px;
+            }
+
+            .guide-row.vertical {
                 flex-direction: column;
+                overflow: visible;
+                scroll-snap-type: none;
+            }
+
+            .guide-item {
+                flex: 0 0 82%;
+                scroll-snap-align: center;
+            }
+
+            .guide-item img {
+                width: 100%;
+                max-height: 340px;
+                object-fit: contain;
             }
 
             .guide-item img:hover {
@@ -699,7 +721,11 @@
             }
 
             .scroll-markers {
-                display: none;
+                display: block;
+                width: 18px;
+                background: rgba(240, 240, 240, 0.9);
+                border-right: none;
+                border-left: 1px solid #e0e0e0;
             }
 
             .chat-area {
@@ -707,13 +733,22 @@
             }
 
             .chat-header {
+                position: relative;
                 padding: 12px 14px;
+                padding-left: 52px;
             }
 
             .sidebar-toggle {
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
+                position: absolute;
+                left: -12px;
+                top: 50%;
+                transform: translateY(-50%);
+                border-radius: 0 10px 10px 0;
+                padding: 10px 12px;
+                box-shadow: 0 4px 12px rgba(0,0,0,0.2);
             }
 
             .chat-messages {


### PR DESCRIPTION
### Motivation
- Improve mobile UX so guide screenshots show as a horizontally-scrollable, larger preview carousel instead of a long vertical list.
- Make the date/side panel toggle more accessible on small screens by placing a bookmark-style button at the left edge of the chat header.
- Restore and adapt the scroll-marker track on mobile so leader markers and quick navigation remain usable on phones.

### Description
- Converted the setup guide to a horizontal carousel on small screens by changing `.guide-row` to horizontal scrolling with `overflow-x: auto`, `scroll-snap-type: x mandatory`, and `-webkit-overflow-scrolling: touch`, and sized `.guide-item` and images for larger previews.
- Added a mobile-specific `.guide-row.vertical` rule to preserve vertical layouts where needed and constrained `.guide-item` to `flex: 0 0 82%` with `scroll-snap-align: center` for centered snapping.
- Repositioned the sidebar toggle into a left-edge bookmark button by making `.sidebar-toggle` absolutely positioned inside `.chat-header` (left offset, rounded right edge, shadow) and added `padding-left` to the header to accommodate it.
- Re-enabled the scroll-marker track on mobile by changing `.scroll-markers` from hidden to visible on small screens and adjusted its width and background to a slimmer, mobile-friendly style.

### Testing
- Started a static server with `python -m http.server 8000` and loaded the page at mobile dimensions (390x844) using a Playwright script, which captured a screenshot at `artifacts/mobile-setup-carousel.png` to verify layout and interactions, and the script completed successfully.
- No automated unit tests were applicable because the change is purely static HTML/CSS adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c2797e7c832d83059442cd238960)