### PR TITLE
Fix mobile sidebar toggle layering and horizontal overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,6 +480,7 @@
             cursor: pointer;
             box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
             transition: left 0.25s ease, box-shadow 0.25s ease, border-radius 0.25s ease;
+            z-index: 950;
         }
 
         .sidebar-toggle:active {
@@ -711,6 +712,7 @@
 
             .app {
                 position: relative;
+                overflow-x: hidden;
             }
 
             .sidebar {
@@ -741,7 +743,7 @@
             }
 
             .chat-area {
-                width: 100%;
+                width: calc(100% - var(--marker-width));
             }
 
             .chat-header {
@@ -765,7 +767,7 @@
 
             .app.sidebar-open .sidebar-toggle {
                 left: calc(min(86vw, 320px) - 1px);
-                border-radius: 10px 0 0 10px;
+                border-radius: 0 10px 10px 0;
                 box-shadow: 0 6px 14px rgba(0,0,0,0.25);
             }
 


### PR DESCRIPTION
### Motivation
- On mobile the sidebar toggle was visually behind the dark `sidebar-overlay` and its rounded corner appeared on the inner side when the panel was opened.  
- The chat content area could still cause horizontal scrolling because the marker rail width wasn't accounted for in the chat area width.

### Description
- Added `z-index: 950` to `.sidebar-toggle` so the toggle sits above the overlay (`.sidebar-overlay` uses `z-index: 800`).
- Kept the toggle's outer rounded corner consistent by changing the open-state radius to `border-radius: 0 10px 10px 0` for mobile open state.
- Prevented stray horizontal scrolling by setting `overflow-x: hidden` on `.app` for mobile and changing `.chat-area` to `width: calc(100% - var(--marker-width))` so the marker rail is included in the math.
- Changes are contained in `index.html` (mobile CSS rules and toggle styles).

### Testing
- Started a local server with `python -m http.server 8000` and captured a mobile viewport screenshot using Playwright (Chromium viewport `390x844`) which produced `artifacts/mobile-sidebar-fix.png`, confirming the toggle is above the overlay and no horizontal overflow is visible; the Playwright run succeeded.  
- Changes were committed to the repo; no runtime JavaScript changes were required for this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981de78c930832d80a32013630df0f0)