### PR TITLE
Remove mobile toggle shadow and reset scroll when opening app

### DIFF
--- a/index.html
+++ b/index.html
@@ -766,13 +766,13 @@
                 transform: translateY(-50%);
                 border-radius: 0 10px 10px 0;
                 padding: 10px 12px;
-                box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+                box-shadow: none;
             }
 
             .app.sidebar-open .sidebar-toggle {
                 left: calc(min(86vw, 320px) - 1px);
                 border-radius: 0 10px 10px 0;
-                box-shadow: 0 6px 14px rgba(0,0,0,0.25);
+                box-shadow: none;
             }
 
             .chat-messages {
@@ -1277,6 +1277,11 @@
             setupScreen.style.display = 'none';
             app.classList.add('active');
             initApp();
+            requestAnimationFrame(() => {
+                window.scrollTo(0, 0);
+                document.documentElement.scrollTop = 0;
+                document.body.scrollTop = 0;
+            });
         });
 
         // ========== 앱 초기화 ==========


### PR DESCRIPTION
### Motivation
- Fix mobile UI so the sidebar toggle no longer shows a drop shadow and the chat header/toggle remain visible when transitioning from the setup screen to the main app view.

### Description
- Removed `box-shadow` from `.sidebar-toggle` and `.app.sidebar-open .sidebar-toggle` in the mobile CSS and added a scroll reset in the `startBtn` click handler using `requestAnimationFrame` with `window.scrollTo(0, 0)` and clearing `document.documentElement.scrollTop`/`document.body.scrollTop` in `index.html`.

### Testing
- Attempted an automated visual test using Playwright to capture a mobile screenshot (`390x844`) after switching to the app view, but the Playwright run timed out and did not complete, and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e4dfe138832d81ca2ecd8a30366f)