### PR TITLE
Reduce mobile chat bubble width and add right margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -791,8 +791,9 @@
             }
 
             .message-bubble {
-                width: calc(100% - 16px);
-                max-width: calc(100% - 16px);
+                width: calc(100% - 28px);
+                max-width: calc(100% - 28px);
+                margin-right: 12px;
             }
 
             .message-bubble .user-name.mobile-only {


### PR DESCRIPTION
### Motivation
- On narrow/mobile view the right-side message bubbles spanned to the very edge of the panel leaving no right padding, so the bubble width needs to be reduced to provide breathing room on the right.

### Description
- Updated mobile CSS in `index.html` to set `.message-bubble` width and `max-width` to `calc(100% - 28px)` and added `margin-right: 12px` to create right-side spacing.

### Testing
- Launched a static server with `python -m http.server 8000` and ran a Playwright script (viewport `430x932`) to capture a screenshot saved as `artifacts/mobile-chat-padding.png`, and the visual spacing change was confirmed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e797d5e8832da1f17524957df1da)