### PR TITLE
Fix mobile bubble sizing and toggle press behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
         }
 
         .sidebar-toggle:active {
-            transform: scale(0.98);
+            transform: none;
         }
 
         .chat-messages {
@@ -769,6 +769,10 @@
                 box-shadow: none;
             }
 
+            .sidebar-toggle:active {
+                transform: translateY(-50%);
+            }
+
             .app.sidebar-open .sidebar-toggle {
                 left: calc(min(86vw, 320px) - 1px);
                 border-radius: 0 10px 10px 0;
@@ -791,9 +795,10 @@
             }
 
             .message-bubble {
-                width: calc(100% - 28px);
-                max-width: calc(100% - 28px);
-                margin-right: 12px;
+                width: 100%;
+                max-width: 100%;
+                margin-right: 0;
+                align-self: stretch;
             }
 
             .message-bubble .user-name.mobile-only {


### PR DESCRIPTION
### Motivation
- Mobile view showed inconsistent message-bubble widths (some days wide and overflowing, others with large right padding), causing layout drift depending on message count.
- The sidebar toggle button produced a noticeable vertical "push-down" when pressed due to a scale transform, creating visual jank on mobile.
- Normalize mobile chat layout and remove the press-induced movement to improve readability and UX on small screens.

### Description
- Modified `index.html` CSS to remove the `.sidebar-toggle:active { transform: scale(0.98); }` behavior and keep the toggle vertically centered instead (`transform: none;` globally, and `transform: translateY(-50%);` inside the mobile media query).
- Adjusted mobile `.message-bubble` rules to `width: 100%`, `max-width: 100%`, `margin-right: 0` and `align-self: stretch` so bubbles consistently fill the available column and no longer vary by message count.
- Changes are limited to CSS in `index.html` and affect only the responsive (mobile) presentation and toggle interaction.

### Testing
- Started a static server with `python -m http.server 8000` and captured a mobile viewport screenshot using a Playwright script (viewport `430x932`), the screenshot `artifacts/mobile-view.png` was produced successfully.
- No automated unit tests apply for this static HTML/CSS fix, visual check via the generated screenshot succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e9dbf2c8832d92835c64a401dd20)