### PR TITLE
Adjust chat bubble widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,14 +521,16 @@
         }
 
         .message-bubble {
-            flex: 1;
-            max-width: calc(700px - var(--marker-width));
+            flex: 0 1 auto;
+            width: fit-content;
+            max-width: min(calc(700px - var(--marker-width)), 90%);
             padding: 8px 12px;
             border-radius: 8px;
             background: white;
             box-shadow: 0 1px 1px rgba(0,0,0,0.1);
             word-wrap: break-word;
             box-sizing: border-box;
+            align-self: flex-start;
         }
 
         .message .time {
@@ -795,10 +797,10 @@
             }
 
             .message-bubble {
-                width: 100%;
-                max-width: 100%;
+                width: fit-content;
+                max-width: 90%;
                 margin-right: 0;
-                align-self: stretch;
+                align-self: flex-start;
             }
 
             .message-bubble .user-name.mobile-only {


### PR DESCRIPTION
### Motivation
- Prevent message bubbles from stretching full-width on wide screens and improve readability by constraining bubble sizing. 
- Ensure consistent left alignment across desktop and mobile responsive layouts.

### Description
- Changed `.message-bubble` sizing in `index.html` from `flex: 1` to `flex: 0 1 auto` and added `width: fit-content` with `max-width: min(calc(700px - var(--marker-width)), 90%)` to limit bubble width. 
- Added `align-self: flex-start` for desktop bubbles to keep left alignment. 
- Updated mobile rules so `.message-bubble` uses `width: fit-content`, `max-width: 90%` and `align-self: flex-start` to avoid full-width bubbles on small viewports.

### Testing
- Attempted automated headless rendering using Playwright with a `file://` URL which failed due to a missing file path and some `page.evaluate` errors. 
- Served the app with `python -m http.server 8000` and re-ran Playwright to capture a screenshot, producing `artifacts/chat-bubble-width.png`, confirming the new bubble sizing visually. 
- No unit tests were added since this is a static HTML/CSS tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ebcee914832d82ff17261c47eda8)