### PR TITLE
Fix iOS Firefox modal freeze and 1995 theme control rendering

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -1286,6 +1286,17 @@ function is1995ThemeActive() {
     return document.documentElement.getAttribute('data-theme') === '1995';
 }
 
+function isIOSFirefox() {
+    const ua = (typeof navigator !== 'undefined' && navigator.userAgent)
+        ? navigator.userAgent
+        : '';
+    return /iPhone|iPad|iPod/i.test(ua) && /FxiOS/i.test(ua);
+}
+
+function is1995AnimationAllowed() {
+    return !isIOSFirefox();
+}
+
 function normalize1995GhostRect(rect) {
     if (!rect) return null;
 
@@ -1380,7 +1391,7 @@ function play1995GhostBox(fromRect, toRect, onFinish) {
         }
     };
 
-    if (!is1995ThemeActive() || !document.body || typeof document.createElement !== 'function') {
+    if (!is1995ThemeActive() || !is1995AnimationAllowed() || !document.body || typeof document.createElement !== 'function') {
         finish();
         return;
     }
@@ -1451,7 +1462,7 @@ function openModal(modalId) {
     modal.classList.add('open');
     modal.setAttribute('aria-hidden', 'false');
 
-    if (!is1995ThemeActive()) {
+    if (!is1995ThemeActive() || !is1995AnimationAllowed()) {
         focusModalCloseButton(modal);
         return;
     }
@@ -1470,6 +1481,7 @@ function closeModal(modalId, restoreFocus = true) {
     if (!modal) return;
 
     const shouldAnimateClose = is1995ThemeActive()
+        && is1995AnimationAllowed()
         && modal.classList.contains('open')
         && !modal.classList.contains('closing');
 
@@ -1504,6 +1516,7 @@ function closeImageModal(restoreFocus = true) {
     if (!modal) return;
 
     const shouldAnimateClose = is1995ThemeActive()
+        && is1995AnimationAllowed()
         && modal.classList.contains('active')
         && !modal.classList.contains('closing');
 
@@ -1931,6 +1944,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () 
 });
 
 // 페이지 로드시 설정 초기화
+document.documentElement.setAttribute('data-ios-firefox', isIOSFirefox() ? 'true' : 'false');
 initSettings();
 
 // ========== ZIP/TXT/CSV 파일 선택 ==========

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1287,6 +1287,27 @@ body {
     text-decoration: none;
 }
 
+/* iOS Firefox(WebKit)에서 3D border 방향이 반대로 렌더링되는 현상 완화 */
+[data-theme="1995"][data-ios-firefox="true"] .setup-step,
+[data-theme="1995"][data-ios-firefox="true"] .leader-filter-panel,
+[data-theme="1995"][data-ios-firefox="true"] .link-item,
+[data-theme="1995"][data-ios-firefox="true"] .footer-link-btn,
+[data-theme="1995"][data-ios-firefox="true"] .header-btn,
+[data-theme="1995"][data-ios-firefox="true"] .capture-btn,
+[data-theme="1995"][data-ios-firefox="true"] .leader-filter-controls button,
+[data-theme="1995"][data-ios-firefox="true"] .report-action-btn,
+[data-theme="1995"][data-ios-firefox="true"] .capture-controls label,
+[data-theme="1995"][data-ios-firefox="true"] .capture-filter-option,
+[data-theme="1995"][data-ios-firefox="true"] .diagnostic-toast-actions button,
+[data-theme="1995"][data-ios-firefox="true"] .theme-btn,
+[data-theme="1995"][data-ios-firefox="true"] .font-btn,
+[data-theme="1995"][data-ios-firefox="true"] .cache-clear-btn,
+[data-theme="1995"][data-ios-firefox="true"] .file-btn,
+[data-theme="1995"][data-ios-firefox="true"] .start-btn,
+[data-theme="1995"][data-ios-firefox="true"] .missing-attachment-help summary {
+    border-color: var(--win31-dark) var(--win31-light) var(--win31-light) var(--win31-dark);
+}
+
 .attachment .file-link:hover {
     background: var(--border-color);
 }


### PR DESCRIPTION
### Motivation
- Address crashes and UI lockups observed only on iOS Firefox when opening modals (capture/settings) and correct inverted-looking 1995-theme control borders on that browser.

### Description
- Add `isIOSFirefox()` UA detection and `is1995AnimationAllowed()` gate to avoid the 1995 ghost-box open/close animation on iOS Firefox, causing modals to open synchronously instead of running the animated code path.
- Set `data-ios-firefox` on the document root at startup to enable targeted CSS fixes (`document.documentElement.setAttribute('data-ios-firefox', ...)`).
- Add CSS override for `[data-theme="1995"][data-ios-firefox="true"]` to flip the 3D border color order for controls and mitigate the inverted/pressed appearance.
- Changes applied in `assets/scripts/app.js` and `assets/styles/app.css` to keep behavior scoped to iOS Firefox only.

### Testing
- Used skills: `chaextractor-maintainer` then `chaextractor-tester` for classification, change planning, and verification steps.
- Ran `git diff --check` (PASS) and `python3 harness/scripts/check_diagnostic_report.py` (PASS).
- Attempted `npm run test:browser` (Playwright smoke tests) but it failed to launch due to missing Playwright browser binaries (error: instructs to run `npx playwright install`), so browser smoke tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e4b9a358832da7cfc83bb1fe6ffc)