### PR TITLE
Gate capture button by date selection and harden modal focus for iOS Firefox

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -1275,10 +1275,17 @@ function rememberModalTrigger() {
     lastModalTrigger = document.activeElement;
 }
 
-function restoreModalTrigger() {
-    if (lastModalTrigger && typeof lastModalTrigger.focus === 'function') {
-        lastModalTrigger.focus();
+function safeFocus(element) {
+    if (!element || typeof element.focus !== 'function') return;
+    try {
+        element.focus();
+    } catch (error) {
+        console.warn('focus-failed', error);
     }
+}
+
+function restoreModalTrigger() {
+    safeFocus(lastModalTrigger);
     lastModalTrigger = null;
 }
 
@@ -1433,9 +1440,7 @@ function play1995GhostBox(fromRect, toRect, onFinish) {
 
 function focusModalCloseButton(modal) {
     const closeButton = modal.querySelector('.modal-close-btn');
-    if (closeButton && typeof closeButton.focus === 'function') {
-        closeButton.focus();
-    }
+    safeFocus(closeButton);
 }
 
 function animate1995Panel(panel, className, fromRect, toRect) {
@@ -3409,7 +3414,7 @@ function initApp() {
     document.getElementById('stats').textContent =
         `${messages.length.toLocaleString()}개 메시지 · ${users.size}명 · ${dates.length}일`;
     if (captureBtn) {
-        captureBtn.disabled = messages.length === 0;
+        captureBtn.disabled = true;
     }
 
     if (dates.length > 0) {
@@ -3568,6 +3573,9 @@ function renderDateList(searchQuery = '') {
 // ========== 날짜 선택 ==========
 function selectDate(date) {
     selectedDate = date;
+    if (captureBtn) {
+        captureBtn.disabled = false;
+    }
 
     const dateObj = new Date(date);
     if (dateObj.getMonth() !== currentMonth.getMonth() ||
@@ -3796,7 +3804,7 @@ function showImage(url, triggerElement = null) {
     modal.classList.add('active');
     modal.setAttribute('aria-hidden', 'false');
 
-    const focusClose = () => document.getElementById('modalClose').focus();
+    const focusClose = () => safeFocus(document.getElementById('modalClose'));
     if (!is1995ThemeActive()) {
         focusClose();
         return;

--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -1275,17 +1275,43 @@ function rememberModalTrigger() {
     lastModalTrigger = document.activeElement;
 }
 
-function safeFocus(element) {
-    if (!element || typeof element.focus !== 'function') return;
+function canUseProgrammaticFocus() {
+    return !isIOSFirefox();
+}
+
+function safeFocus(element, options) {
+    if (!canUseProgrammaticFocus()) return false;
+    if (!element || typeof element.focus !== 'function') return false;
     try {
-        element.focus();
+        element.focus(options);
+        return true;
     } catch (error) {
-        console.warn('focus-failed', error);
+        return false;
     }
 }
 
+function focusModalWhenReady(modal, maxAttempts = 8) {
+    if (!canUseProgrammaticFocus()) return;
+    if (!modal) return;
+
+    const closeButton = modal.querySelector('.modal-close-btn');
+    if (!closeButton) return;
+
+    const tryFocus = (attempt) => {
+        const isOpen = modal.classList.contains('open') || modal.classList.contains('active');
+        const isHiddenByAnimation = modal.classList.contains('win31-window-hidden') || modal.classList.contains('closing');
+        if (isOpen && !isHiddenByAnimation && safeFocus(closeButton, { preventScroll: true })) {
+            return;
+        }
+        if (attempt >= maxAttempts) return;
+        requestAnimationFrame(() => tryFocus(attempt + 1));
+    };
+
+    tryFocus(0);
+}
+
 function restoreModalTrigger() {
-    safeFocus(lastModalTrigger);
+    safeFocus(lastModalTrigger, { preventScroll: true });
     lastModalTrigger = null;
 }
 
@@ -1439,8 +1465,7 @@ function play1995GhostBox(fromRect, toRect, onFinish) {
 }
 
 function focusModalCloseButton(modal) {
-    const closeButton = modal.querySelector('.modal-close-btn');
-    safeFocus(closeButton);
+    focusModalWhenReady(modal);
 }
 
 function animate1995Panel(panel, className, fromRect, toRect) {
@@ -3804,7 +3829,7 @@ function showImage(url, triggerElement = null) {
     modal.classList.add('active');
     modal.setAttribute('aria-hidden', 'false');
 
-    const focusClose = () => safeFocus(document.getElementById('modalClose'));
+    const focusClose = () => focusModalWhenReady(modal);
     if (!is1995ThemeActive()) {
         focusClose();
         return;


### PR DESCRIPTION
### Motivation
- Prevent users from opening the capture flow when no date is selected by making the capture button disabled until a date is chosen. 
- Investigate and mitigate a bug on iPhone Firefox where opening any modal sometimes triggers the diagnostic report modal first due to focus-related exceptions. 
- Work followed the `chaextractor-maintainer` decision workflow and `chaextractor-tester` validation steps to limit scope to implementation and verification.

### Description
- In `assets/scripts/app.js` set the capture button to disabled on app init (`initApp`) and enable it only from `selectDate`, so capture actions require an explicit date selection. 
- Added a defensive `safeFocus(element)` helper and routed modal focus operations through it (used by `restoreModalTrigger`, `focusModalCloseButton`, image modal focus callbacks) to avoid uncaught focus exceptions on iOS Firefox. 
- Kept changes local to UI modal and capture gating logic (`assets/scripts/app.js`) without altering parser behavior or public requirements documents.

### Testing
- Ran `python3 harness/scripts/check_modal_escape.py` and it passed (`PASS modal escape`).
- Ran `python3 harness/scripts/check_ui_smoke.py` and it passed (`PASS UI smoke`).
- Ran `python3 harness/scripts/check_diagnostic_report.py` and it passed (`PASS diagnostic report`).
- Ran parser golden suite via `python3 harness/scripts/run_parser_golden.py` and all fixtures passed (`PASS` for android-files, android-sample, ios-minimal, ios-missing-photo-guidance, macos-csv, security-xss, windows-attachments-unsupported, windows-minimal).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09eb44fac0832dbcce0d573aa4c9a4)